### PR TITLE
Makes automatic rule translation to non-English locale more efficient

### DIFF
--- a/sources/FilerRule.cpp
+++ b/sources/FilerRule.cpp
@@ -15,8 +15,7 @@ FilerRule::FilerRule()
 	fTestList(NULL),
  	fActionList(NULL),
 	fMode(FILER_RULE_ALL),
-	fDisabled(false),
-	fLocale(true)
+	fDisabled(false)
 {
 	fTestList = new BObjectList<BMessage>(20, true);
 	fActionList = new BObjectList<BMessage>(20, true);
@@ -30,8 +29,7 @@ FilerRule::FilerRule(FilerRule& rule)
 	fTestList(NULL),
  	fActionList(NULL),
 	fMode(FILER_RULE_ALL),
-	fDisabled(false),
-	fLocale(true)
+	fDisabled(false)
 {
 	fTestList = new BObjectList<BMessage>(20, true);
 	fActionList = new BObjectList<BMessage>(20, true);

--- a/sources/FilerRule.h
+++ b/sources/FilerRule.h
@@ -55,8 +55,6 @@ public:
 			bool				Disabled() const { return fDisabled; }
 			void				Disabled(bool disabled) { fDisabled = disabled; }
 			void				Toggle() { fDisabled = !fDisabled; }
-			bool				Locale() const { return fLocale; }
-			void				Locale(bool locale) { fLocale = locale; }
 			
 private:
 	BObjectList<BMessage>*		fTestList;
@@ -65,7 +63,6 @@ private:
 	BString						fDescription;
 	int64						fID;
 	bool						fDisabled;
-	bool						fLocale;
 };
 
 #endif	// FILER_RULE_H

--- a/sources/MainWindow.cpp
+++ b/sources/MainWindow.cpp
@@ -164,6 +164,7 @@ MainWindow::SaveSettings()
 			msg.AddRect("pos", pos);
 			msg.AddInt32("tab", tab);
 			msg.AddBool("match", match);
+			msg.AddBool("locale", true);
 			msg.Flatten(&file);
 		}
 	}

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -86,7 +86,7 @@ OPTIMIZE :=
 # 	will recreate only the "locales/en.catkeys" file. Use it as a template
 # 	for creating catkeys for other languages. All localization files must be
 # 	placed in the "locales" subdirectory.
-LOCALES = en
+LOCALES = en de
 
 #	Specify all the preprocessor symbols to be defined. The symbols will not
 #	have their values set automatically; you must supply the value (if any) to

--- a/sources/RuleRunner.h
+++ b/sources/RuleRunner.h
@@ -48,8 +48,9 @@ public:
 			status_t	RunRule(FilerRule* rule, entry_ref& ref);
 };
 
-status_t LoadRules(BObjectList<FilerRule> *ruleList);
-status_t SaveRules(BObjectList<FilerRule> *ruleList);
+status_t	LoadRules(BObjectList<FilerRule>* ruleList);
+status_t	SaveRules(const BObjectList<FilerRule>* ruleList);
+void		AddDefaultRules(BObjectList<FilerRule>* ruleList);
 
 
 // Some convenience functions. Deleting the returned BMessage is the

--- a/sources/RuleTab.cpp
+++ b/sources/RuleTab.cpp
@@ -36,13 +36,7 @@ RuleTab::RuleTab()
 	fRuleList = new BObjectList<FilerRule>(20, true);
 	LoadRules(fRuleList);
 
-	for (int32 i = 0; i < fRuleList->CountItems(); i++)
-		fRuleItemList->AddItem(new RuleItem(fRuleList->ItemAt(i)));
-	
-	fRuleItemList->MakeFocus();
-	if (fRuleItemList->CountItems() > 0)
-		fRuleItemList->Select(0L);
-	else {
+	if (fRuleList->CountItems() == 0) {
 		BAlert* alert = new BAlert("Filer",
 			"It appears that there aren't any rules for "
 			"organizing files. Would you like Filer to "
@@ -50,47 +44,17 @@ RuleTab::RuleTab()
 			"No", "Yes");
 
 		if (alert->Go() == 1) {
-			FilerRule* rule = new FilerRule();
-
-			// NOTE: If actions 
-			rule->AddTest(MakeTest("Type", "is", "text/plain"));
-			rule->AddAction(MakeAction("Move to folder…", "/boot/home/Documents"));
-			rule->SetDescription("Store text files in my Documents folder");
-			AddRule(rule);
-
-			rule = new FilerRule();
-			rule->AddTest(MakeTest("Type", "is", "application/pdf"));
-			rule->AddAction(MakeAction("Move to folder…", "/boot/home/Documents"));
-			rule->SetDescription("Store PDF files in my Documents folder");
-			AddRule(rule);
-
-			rule = new FilerRule();
-			rule->AddTest(MakeTest("Type", "starts with", "image/"));
-			rule->AddAction(MakeAction("Move to folder…", "/boot/home/Pictures"));
-			rule->SetDescription("Store pictures in my Pictures folder");
-			AddRule(rule);
-
-			rule = new FilerRule();
-			rule->AddTest(MakeTest("Type", "starts with","video/"));
-			rule->AddAction(MakeAction("Move to folder…", "/boot/home/Videos"));
-			rule->SetDescription("Store movie files in my Videos folder");
-			AddRule(rule);
-
-			rule = new FilerRule();
-			rule->AddTest(MakeTest("Name", "ends with", ".zip"));
-			rule->AddAction(MakeAction("Shell command…",
-				"unzip %FULLPATH% -d /boot/home/Desktop"));
-			rule->SetDescription("Extract ZIP files to the Desktop");
-			AddRule(rule);
-
-//			rule = new FilerRule();
-//			rule->AddTest(MakeTest("","",""));
-//			rule->AddAction(MakeAction("",""));
-//			rule->SetDescription("");
-//			AddRule(rule);
+			AddDefaultRules(fRuleList);
+			SaveRules(fRuleList);
 		}
-		SaveRules(fRuleList);
 	}
+
+	for (int32 i = 0; i < fRuleList->CountItems(); i++)
+		fRuleItemList->AddItem(new RuleItem(fRuleList->ItemAt(i)));
+
+	fRuleItemList->MakeFocus();
+	if (fRuleItemList->CountItems() > 0)
+		fRuleItemList->Select(0L);
 }
 
 

--- a/sources/locales/de.catkeys
+++ b/sources/locales/de.catkeys
@@ -1,0 +1,28 @@
+1	German	application/x-vnd.dw-Filer	2164702911
+Add to archive…	RuleRunner		Zu Archiv hinzufügen…
+contains	RuleRunner		enthält
+Continue	RuleRunner		Weiter
+Copy to folder…	RuleRunner		Kopieren nach…
+Delete	RuleRunner		Löschen
+does not contain	RuleRunner		enthält nicht
+ends with	RuleRunner		endet mit
+is	RuleRunner		ist
+is after	RuleRunner		nach
+is at least	RuleRunner		ist mindestens
+is at most	RuleRunner		ist höchstens
+is before	RuleRunner		vor
+is less than	RuleRunner		ist weniger als
+is more than	RuleRunner		ist mehr als
+is not	RuleRunner		ist nicht
+Location	RuleRunner		Ort
+Move to folder…	RuleRunner		Verschieben nach…
+Move to Trash	RuleRunner		In den Papierkorb verschieben
+Name	RuleRunner		Name
+Open	RuleRunner		Öffnen
+Rename to…	RuleRunner		Umbenennen zu…
+Shell command…	RuleRunner		Konsolenbefehl…
+Size	RuleRunner		Größe
+starts with	RuleRunner		beginnt mit
+Type	RuleRunner		Typ
+Filer	System name		Filer
+

--- a/sources/locales/en.catkeys
+++ b/sources/locales/en.catkeys
@@ -1,27 +1,27 @@
 1	English	application/x-vnd.dw-Filer	2164702911
-Filer	System name		Filer
 Add to archive…	RuleRunner		Add to archive…
-is not	RuleRunner		is not
-Location	RuleRunner		Location
-Move to Trash	RuleRunner		Move to Trash
-is at least	RuleRunner		is at least
-is before	RuleRunner		is before
-starts with	RuleRunner		starts with
-Move to folder…	RuleRunner		Move to folder…
-Shell command…	RuleRunner		Shell command…
+contains	RuleRunner		contains
 Continue	RuleRunner		Continue
-Name	RuleRunner		Name
-is at most	RuleRunner		is at most
-is	RuleRunner		is
-is more than	RuleRunner		is more than
-is less than	RuleRunner		is less than
-Rename to…	RuleRunner		Rename to…
-Type	RuleRunner		Type
 Copy to folder…	RuleRunner		Copy to folder…
 Delete	RuleRunner		Delete
-ends with	RuleRunner		ends with
-Open	RuleRunner		Open
-contains	RuleRunner		contains
 does not contain	RuleRunner		does not contain
-Size	RuleRunner		Size
+ends with	RuleRunner		ends with
+is	RuleRunner		is
 is after	RuleRunner		is after
+is at least	RuleRunner		is at least
+is at most	RuleRunner		is at most
+is before	RuleRunner		is before
+is less than	RuleRunner		is less than
+is more than	RuleRunner		is more than
+is not	RuleRunner		is not
+Location	RuleRunner		Location
+Move to folder…	RuleRunner		Move to folder…
+Move to Trash	RuleRunner		Move to Trash
+Name	RuleRunner		Name
+Open	RuleRunner		Open
+Rename to…	RuleRunner		Rename to…
+Shell command…	RuleRunner		Shell command…
+Size	RuleRunner		Size
+starts with	RuleRunner		starts with
+Type	RuleRunner		Type
+Filer	System name		Filer

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -35,6 +35,7 @@ App::App()
 	fMainWin(NULL),
 	fQuitRequested(false),
 	fMatchSetting(false),
+	fSupportLocale(false),
 	fDoAll(false),
 	fReplace(false)
 {
@@ -70,23 +71,11 @@ App::LoadRuleSettings()
 			if ((file.InitCheck() == B_OK) && (msg.Unflatten(&file) == B_OK)) {
 				if (msg.FindBool("match", &fMatchSetting) != B_OK)
 					fMatchSetting = false;
+				if (msg.FindBool("locale", &fSupportLocale) != B_OK)
+					fSupportLocale = false;
 			}
 		}
 	}
-}
-
-
-bool
-App::GetMatchSetting()
-{
-	return fMatchSetting;
-}
-
-
-void
-App::ToggleMatchSetting()
-{
-	fMatchSetting = !fMatchSetting;
 }
 
 

--- a/sources/main.h
+++ b/sources/main.h
@@ -34,8 +34,10 @@ public:
 	void			ShowHTML(const char* docfile);
 	void			FileRef(entry_ref ref);
 
-	bool			GetMatchSetting();
-	void			ToggleMatchSetting();
+	bool			GetMatchSetting() const { return fMatchSetting; }
+	void			ToggleMatchSetting() { fMatchSetting = !fMatchSetting; }
+
+	bool			GetSupportLocale() const { return fSupportLocale; }
 
 	bool			DoAll() const { return fDoAll; }
 	void			DoAll(bool doAll) { fDoAll = doAll; }
@@ -51,6 +53,7 @@ private:
 	
 	bool			fQuitRequested;
 	bool 			fMatchSetting;
+	bool 			fSupportLocale;
 
 	bool			fDoAll;
 	bool			fReplace;


### PR DESCRIPTION
and robust. Instead of embedding a boolean flag in every rule, simply
add a flag to the settings file.

Also includes changes/additions from humdingerb:

	sorted en.catkeys
	new de.catkeys