### PR TITLE
Save action type code of int8 instead of action type string to

### DIFF
--- a/sources/ActionView.cpp
+++ b/sources/ActionView.cpp
@@ -42,12 +42,13 @@ ActionView::ActionView(const char* name, BMessage* action, const int32& flags)
 	if (action) {
 		fAction = new BMessage(*action);
 
-		BString str;
-		if (fAction->FindString("name", &str) == B_OK)
-			SetAction(str.String());
+		int8 type;
+		if (fAction->FindInt8("type", &type) == B_OK)
+			SetAction(type);
 		else
 			usedefaults = true;
 
+		BString str;
 		if (!usedefaults && fAction->FindString("value", &str) == B_OK)
 			fValueBox->SetText(str.String());
 		else
@@ -59,11 +60,11 @@ ActionView::ActionView(const char* name, BMessage* action, const int32& flags)
 		if (!fAction)
 			fAction = new BMessage;
 
-		BString str;
-		if (fActions.FindString("actions", 0, &str) == B_OK)
-			SetAction(str.String());
+		int8 type;
+		if (fActions.FindInt8("actions", 0, &type) == B_OK)
+			SetAction(type);
 		else
-			SetAction("Nothing");
+			SetAction(0);
 
 		fValueBox->SetText("");
 	}
@@ -107,9 +108,9 @@ ActionView::MessageReceived(BMessage* msg)
 	{
 		case MSG_ACTION_CHOSEN:
 		{
-			BString name;
-			if (msg->FindString("name", &name) == B_OK)
-				SetAction(name.String());
+			int8 type;
+			if (msg->FindInt8("type", &type) == B_OK)
+				SetAction(type);
 			break;
 		}
 		default:
@@ -134,19 +135,18 @@ ActionView::GetAction() const
 
 
 void
-ActionView::SetAction(const char* name)
+ActionView::SetAction(int8 type)
 {
-	BString namestr(name);
-	
-	if (fAction->FindString("name", &namestr) == B_OK)
-		fAction->ReplaceString("name", name);
+	int8 tmpType;
+	if (fAction->FindInt8("type", &tmpType) == B_OK)
+		fAction->ReplaceInt8("type", type);
 	else
-		fAction->AddString("name", name);
+		fAction->AddInt8("type", type);
+
+	BString name(sActions[type].locale);
 	fActionField->MenuItem()->SetLabel(name);
 
-	namestr = name;
-
-	if (namestr.FindFirst("…") >= 0) {
+	if (name.FindFirst("…") >= 0) {
 		if (fValueBox->IsHidden())
 			fValueBox->Show();
 	} else {

--- a/sources/ActionView.h
+++ b/sources/ActionView.h
@@ -30,7 +30,7 @@ public:
 
 private:
 	BPopUpMenu*		ActionMenu() const;
-	void			SetAction(const char* name);
+	void			SetAction(int8 type);
 	
 	BMenuField*		fActionField;
 	

--- a/sources/RuleRunner.h
+++ b/sources/RuleRunner.h
@@ -14,6 +14,14 @@
 #include <Entry.h>
 #include <Message.h>
 
+struct NamePair
+{
+	const char* const english;
+	const char* const locale;
+};
+
+extern const NamePair sActions[];
+
 enum
 {
 	TEST_TYPE_NULL = 0,
@@ -58,6 +66,6 @@ void		AddDefaultRules(BObjectList<FilerRule>* ruleList);
 BMessage*	MakeTest(const char* name, const char* mode, const char* value,
 				const char* mimeType = NULL, const char* typeName = NULL,
 				const char* attrType = NULL, const char* attrName = NULL);
-BMessage*	MakeAction(const char* name, const char* value);
+BMessage*	MakeAction(int8 type, const char* value);
 
 #endif	// RULERUNNER_H

--- a/sources/RuleTab.cpp
+++ b/sources/RuleTab.cpp
@@ -34,7 +34,7 @@ RuleTab::RuleTab()
 	_BuildLayout();
 
 	fRuleList = new BObjectList<FilerRule>(20, true);
-	LoadRules(fRuleList);
+	fRuleList = static_cast<App*>(be_app)->GetRuleList();
 
 	if (fRuleList->CountItems() == 0) {
 		BAlert* alert = new BAlert("Filer",

--- a/sources/main.h
+++ b/sources/main.h
@@ -44,6 +44,8 @@ public:
 	bool			Replace() const { return fReplace; }
 	void			Replace(bool replace) { fReplace = replace; }
 
+	BObjectList<FilerRule>*	GetRuleList() const { return fRuleList; }
+
 private:
 	void			LoadRuleSettings();
 //	void			SaveRuleSettings();


### PR DESCRIPTION
FilerRules file. This is more efficient. It also make it easier to
translate action menu item labels for different locales.

Load FilerRules only once, in main.cpp. The Rules tab now uses the rule
list generated in main.cpp instead of loading FilerRules for the second
time and then maintain its own rule list.