### PR TITLE
Save mode type code of int8 instead of mode type string to FilerRules

### DIFF
--- a/sources/ModeMenu.cpp
+++ b/sources/ModeMenu.cpp
@@ -42,11 +42,11 @@ ModeMenu::AddDynamicItem(add_state state)
 	if (RuleRunner::GetCompatibleModes(label, modes) != B_OK)
 		return false;
 
-	BString modestr;
-	for (int32 i = 0; modes.FindString("modes", i, &modestr) == B_OK; i++) {
+	int8 modetype;
+	for (int32 i = 0; modes.FindInt8("modes", i, &modetype) == B_OK; i++) {
 		BMessage* msg = new BMessage(MSG_MODE_CHOSEN);
-		msg->AddString("mode", modestr);
-		AddItem(new BMenuItem(modestr.String(), msg));
+		msg->AddInt8("mode", modetype);
+		AddItem(new BMenuItem(sModeTypes[modetype].locale, msg));
 	}
 
 	SetTargetForItems(fTarget);

--- a/sources/RuleRunner.h
+++ b/sources/RuleRunner.h
@@ -20,6 +20,7 @@ struct NamePair
 	const char* const locale;
 };
 
+extern const NamePair sModeTypes[];
 extern const NamePair sActions[];
 
 enum
@@ -49,7 +50,7 @@ public:
 //	static	BString		GetEditorTypeForTest(const char* testname);
 
 	static	int32		GetDataTypeForTest(const char* testname);
-	static	int32		GetDataTypeForMode(const char* modename);
+	static	int32		GetDataTypeForMode(int8 modetype);
 
 			bool		IsMatch(const BMessage& test, const entry_ref& ref);
 			status_t	RunAction(const BMessage& test, entry_ref& ref);
@@ -63,7 +64,7 @@ void		AddDefaultRules(BObjectList<FilerRule>* ruleList);
 
 // Some convenience functions. Deleting the returned BMessage is the
 // responsibility of the caller
-BMessage*	MakeTest(const char* name, const char* mode, const char* value,
+BMessage*	MakeTest(const char* name, int8 modetype, const char* value,
 				const char* mimeType = NULL, const char* typeName = NULL,
 				const char* attrType = NULL, const char* attrName = NULL);
 BMessage*	MakeAction(int8 type, const char* value);

--- a/sources/TestView.h
+++ b/sources/TestView.h
@@ -31,7 +31,7 @@ public:
 private:
 	BPopUpMenu*	TestMenu() const;
 	bool		SetTest(BMessage* msg);
-	void		SetMode(const char* mode);
+	void		SetMode(int8 modetype);
 	const char*	GetValue();
 	
 	BMenu*		AddMenuSorted(BMenu* parent, const char* name) const;


### PR DESCRIPTION
file. This makes the menu labels for mode types in TestView
automatically match any user-preferred language/locale.