### PR TITLE
Fixes issue #47: a hidden bug in AutoTextControl exposed by nameless views

### DIFF
--- a/sources/AutoTextControl.cpp
+++ b/sources/AutoTextControl.cpp
@@ -187,7 +187,7 @@ AutoTextControlFilter::Filter(BMessage* msg, BHandler** target)
 	msg->FindInt32("modifiers", &mod);
 
 	BView* view = dynamic_cast<BView*>(*target);
-	if (!view || strcmp("_input_", view->Name()) != 0)
+	if (view != NULL || view->Name() != NULL && strcmp("_input_", view->Name()))
 		return B_DISPATCH_MESSAGE;
 	
 	AutoTextControl* text = dynamic_cast<AutoTextControl*>(view->Parent());


### PR DESCRIPTION
The `AutoTextContorlFilter::Filter` function assumes that the `BView` target has a
name. When the target doesn't, a null pointer is passed to `strcmp()`
and causes Filer to crash.