### PR TITLE
Save test type code of int8 instead of test type string to FilerRules file.

### DIFF
--- a/sources/ActionView.cpp
+++ b/sources/ActionView.cpp
@@ -161,11 +161,11 @@ ActionView::ActionMenu() const
 {
 	BPopUpMenu* menu = new BPopUpMenu("");
 
-	BString name;
-	for (int32 i = 0; fActions.FindString("actions", i, &name) == B_OK; i++) {
+	int8 type;
+	for (int32 i = 0; fActions.FindInt8("actions", i, &type) == B_OK; i++) {
 		BMessage* msg = new BMessage(MSG_ACTION_CHOSEN);
-		msg->AddString("name", name.String());
-		menu->AddItem(new BMenuItem(name.String(), msg));
+		msg->AddInt8("name", type);
+		menu->AddItem(new BMenuItem(sActions[type].locale, msg));
 	}
 
 	return menu;

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -105,7 +105,7 @@ SYMBOLS :=
 
 #	Includes debug information, which allows the binary to be debugged easily.
 #	If set to "TRUE", debug info will be created.
-DEBUGGER := 
+DEBUGGER := TRUE
 
 #	Specify any additional compiler flags to be used.
 COMPILER_FLAGS = -Woverloaded-virtual -funsigned-bitfields -Wwrite-strings

--- a/sources/ModeMenu.cpp
+++ b/sources/ModeMenu.cpp
@@ -38,8 +38,8 @@ ModeMenu::AddDynamicItem(add_state state)
 	RemoveItems(0, CountItems(), true);
 
 	BMessage modes;
-
-	if (RuleRunner::GetCompatibleModes(label, modes) != B_OK)
+	if (RuleRunner::GetCompatibleModes(GetTestType(label.String()), modes)
+		!= B_OK)
 		return false;
 
 	int8 modetype;

--- a/sources/RuleRunner.h
+++ b/sources/RuleRunner.h
@@ -20,6 +20,7 @@ struct NamePair
 	const char* const locale;
 };
 
+extern const NamePair sTestTypes[];
 extern const NamePair sModeTypes[];
 extern const NamePair sActions[];
 
@@ -42,14 +43,14 @@ public:
 						~RuleRunner();
 
 	static	void		GetTestTypes(BMessage& msg);
-	static	status_t	GetCompatibleModes(const char* testtype, BMessage& msg);
+	static	status_t	GetCompatibleModes(int8 testtype, BMessage& msg);
 	static	status_t	GetCompatibleModes(const int32& type, BMessage& msg);
 	static	void		GetModes(BMessage& msg);
 	static	void		GetActions(BMessage& msg);
 
 //	static	BString		GetEditorTypeForTest(const char* testname);
 
-	static	int32		GetDataTypeForTest(const char* testname);
+	static	int32		GetDataTypeForTest(int8 testtype);
 	static	int32		GetDataTypeForMode(int8 modetype);
 
 			bool		IsMatch(const BMessage& test, const entry_ref& ref);
@@ -59,14 +60,8 @@ public:
 
 status_t	LoadRules(BObjectList<FilerRule>* ruleList);
 status_t	SaveRules(const BObjectList<FilerRule>* ruleList);
+int8		AttributeTestType();
+int8		GetTestType(const char* name);
 void		AddDefaultRules(BObjectList<FilerRule>* ruleList);
-
-
-// Some convenience functions. Deleting the returned BMessage is the
-// responsibility of the caller
-BMessage*	MakeTest(const char* name, int8 modetype, const char* value,
-				const char* mimeType = NULL, const char* typeName = NULL,
-				const char* attrType = NULL, const char* attrName = NULL);
-BMessage*	MakeAction(int8 type, const char* value);
 
 #endif	// RULERUNNER_H


### PR DESCRIPTION
This concludes the abstraction/extraction of menu labels in TestView and ActionView and truly fixes issue #12.