### PR TITLE
Fixes issue #64:

### DIFF
--- a/sources/AutoTextControl.cpp
+++ b/sources/AutoTextControl.cpp
@@ -41,6 +41,7 @@ AutoTextControl::AutoTextControl(const char* name, const char* label,
 	:
 	BTextControl(name, label, text, msg, flags),
 	fEmpty(false),
+	fOnlyDigits(false),
  	fFilter(NULL),
  	fCharLimit(0)
 {
@@ -192,6 +193,25 @@ uint32
 AutoTextControl::GetCharacterLimit(const uint32& limit)
 {
 	return fCharLimit;
+}
+
+
+void
+AutoTextControl::OnlyAllowDigits(bool turnOn)
+{
+	if (fOnlyDigits == turnOn)
+		return;
+
+	fOnlyDigits = turnOn;
+	BTextView* view = TextView();
+	void (BTextView::*f)(uint32 byte) = turnOn ? &BTextView::DisallowChar
+												: &BTextView::AllowChar;
+
+	for (uint32 i = 0; i < '0'; i++)
+		(view->*f)(i);
+
+	for (uint32 i = '9' + 1; i < 256; i++)
+		(view->*f)(i);
 }
 
 

--- a/sources/AutoTextControl.h
+++ b/sources/AutoTextControl.h
@@ -51,6 +51,8 @@ public:
 	
 			void	SetCharacterLimit(const uint32& limit);
 			uint32	GetCharacterLimit(const uint32& limit);
+
+			void	OnlyAllowDigits(bool turnOn);
 	
 private:
 	friend AutoTextControlFilter;
@@ -58,6 +60,7 @@ private:
 	AutoTextControlFilter*	fFilter;
 	uint32					fCharLimit;
 	bool					fEmpty;
+	bool					fOnlyDigits;
 };
 
 /*

--- a/sources/TestView.cpp
+++ b/sources/TestView.cpp
@@ -362,10 +362,14 @@ TestView::SetTest()
 	STRACE(("-------------------------\n"));
 
 	if (fDataType == TEST_TYPE_NUMBER) {
+		fValueBox->OnlyAllowDigits(true);
 		if (fUnitField->IsHidden())
 			fUnitField->Show();
-	} else if (!fUnitField->IsHidden())
+	} else {
+		fValueBox->OnlyAllowDigits(false);
+		if (!fUnitField->IsHidden())
 			fUnitField->Hide();
+	}
 }
 
 


### PR DESCRIPTION
Only allow decimal digits 0-9 in the text control for the Size test.