### PR TITLE
Allow decimal point "." for size units except bytes.

### DIFF
--- a/sources/RuleRunner.cpp
+++ b/sources/RuleRunner.cpp
@@ -572,9 +572,11 @@ IsSizeMatch(const BMessage& test, const entry_ref& ref)
 	file.GetSize(&fileSize);
 	file.Unset();
 
-	off_t size = atoll(value.String());
+	double sz = strtod(value.String(), NULL);
 	for (int32 i = 0; i < unit; i++)
-		size <<= 10;
+		sz *= 1024;
+
+	off_t size = static_cast<off_t>(round(sz));
 
 	bool result;
 

--- a/sources/TestView.cpp
+++ b/sources/TestView.cpp
@@ -94,7 +94,6 @@ TestView::TestView(const char* name, BMessage* test, const int32& flags)
 	}
 
 	SetMode();
-	SetUnit();
 	SetTest();
 }
 
@@ -363,10 +362,13 @@ TestView::SetTest()
 
 	if (fDataType == TEST_TYPE_NUMBER) {
 		fValueBox->OnlyAllowDigits(true);
+		SetUnit();
+
 		if (fUnitField->IsHidden())
 			fUnitField->Show();
 	} else {
 		fValueBox->OnlyAllowDigits(false);
+
 		if (!fUnitField->IsHidden())
 			fUnitField->Hide();
 	}
@@ -384,6 +386,14 @@ void
 TestView::SetUnit()
 {
 	fUnitField->MenuItem()->SetLabel(sSizeUnits[fUnit]);
+
+	const char dot = '.';
+	BTextView* view = fValueBox->TextView();
+
+	if (fUnit > 0)
+		view->AllowChar(dot);
+	else
+		view->DisallowChar(dot);
 }
 
 


### PR DESCRIPTION
Fixes part of issue #74. I will try to localize the dot "." if I can get g++ to cooperate.