### PR TITLE
Unknown/generic file type will not always avoid being filtered.

### DIFF
--- a/sources/TypedRefFilter.cpp
+++ b/sources/TypedRefFilter.cpp
@@ -53,10 +53,6 @@ bool
 TypedRefFilter::Filter(const entry_ref* ref, BNode* node, struct stat_beos* st,
 	const char* filetype)
 {
-	 if (filetype == NULL || *filetype == '\0'
-		|| strcmp(filetype, "application/octet-stream") == 0)
-		return true;
-
 	// it does not match the entry filter, then we automatically kick back a false
 	if ( !( ((B_DIRECTORY_NODE & NodeType()) && S_ISDIR(st->st_mode))
 		|| ((B_FILE_NODE & NodeType()) && S_ISREG(st->st_mode))
@@ -67,5 +63,6 @@ TypedRefFilter::Filter(const entry_ref* ref, BNode* node, struct stat_beos* st,
 	if (fFileType.IsEmpty())
 		return true;
 
-	return S_ISDIR(st->st_mode) || fFileType == filetype;
+	return S_ISDIR(st->st_mode) || fFileType == filetype
+			|| strcmp(filetype, "application/octet-stream") == 0;
 }


### PR DESCRIPTION
It will not be filtered only if the file is not a folder.
Fixes issue #84.