### PR TITLE
Pass heap-allocated arguments to member function AddItem

### DIFF
--- a/sources/FSUtils.cpp
+++ b/sources/FSUtils.cpp
@@ -172,6 +172,7 @@ status_t MoveFile(BEntry* srcentry, BEntry* destentry, bool clobber)
 }
 
 
+#if 0
 const char* GetValidName(BEntry* entry)
 {
 	// given a particular location, this will (1) check to see if said entry
@@ -207,6 +208,7 @@ const char* GetValidName(BEntry* entry)
 
 	return path.Path();
 }
+#endif
 
 
 bool IsFilenameChar(char c)

--- a/sources/Makefile_AutoFiler
+++ b/sources/Makefile_AutoFiler
@@ -54,7 +54,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be
+LIBS = be $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative

--- a/sources/RefStorage.cpp
+++ b/sources/RefStorage.cpp
@@ -78,14 +78,11 @@ LoadFolders(BListView* folderList)
 			if (entry.GetRef(&ref) != B_OK)
 				continue;
 
-			RefStorage refholder(ref);
-			gRefStructList.AddItem(&refholder);
-			count++;
-		} else {
-			BStringItem item(str);
-			folderList->AddItem(&item);
-			count++;
-		}
+			gRefStructList.AddItem(new RefStorage(ref));
+		} else
+			folderList->AddItem(new BStringItem(str));
+
+		count++;
 	}
 
 	if (count < i)


### PR DESCRIPTION
Reverts previous changes that allowed gcc5 linker to succeed.
Fixes #95

Also, make AutoFiler pass gcc5 linker.
Fixes #97