### PR TITLE
Use B_TRANSLATE_MARK_ALL when calling AddRemoveButtons constructor

### DIFF
--- a/sources/AddRemoveButtons.cpp
+++ b/sources/AddRemoveButtons.cpp
@@ -14,7 +14,7 @@
 #include "FilerDefs.h"
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "AddRemoveButtons"
+#define B_TRANSLATION_CONTEXT ADD_REMVOE_BUTTONS_CONTEXT
 
 
 AddRemoveButtons::AddRemoveButtons(uint32 add, uint32 remove, BView* target,

--- a/sources/AddRemoveButtons.h
+++ b/sources/AddRemoveButtons.h
@@ -12,8 +12,10 @@
 #include <Button.h>
 #include <Catalog.h>
 
+#define ADD_REMVOE_BUTTONS_CONTEXT "AddRemoveButtons"
+
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "AddRemoveButtons"
+#define B_TRANSLATION_CONTEXT ADD_REMVOE_BUTTONS_CONTEXT
 
 
 class AddRemoveButtons : public BView

--- a/sources/RuleTab.cpp
+++ b/sources/RuleTab.cpp
@@ -103,7 +103,8 @@ RuleTab::_BuildLayout()
 
 	fAddRemoveButtons = new AddRemoveButtons(MSG_SHOW_ADD_WINDOW,
 		MSG_REMOVE_RULE, this, height, B_USE_DEFAULT_SPACING,
-		B_TRANSLATE("Add rule"), B_TRANSLATE("Remove rule"));
+		B_TRANSLATE_MARK_ALL("Add rule", ADD_REMVOE_BUTTONS_CONTEXT, NULL),
+		B_TRANSLATE_MARK_ALL("Remove rule", ADD_REMVOE_BUTTONS_CONTEXT, NULL));
 	fAddRemoveButtons->SetRemoveEnabled(false);
 
 	fMoveUpButton = new BButton("moveupbutton", B_TRANSLATE("Move up"),


### PR DESCRIPTION
instead of B_TRANSLATE to avoid translating already translated strings