### PR TITLE
Make source/target folders of ConflictWindow clickable.

### DIFF
--- a/sources/ConflictWindow.h
+++ b/sources/ConflictWindow.h
@@ -15,6 +15,7 @@
 
 class ConflictWindow : public BWindow
 {
+	const char*	fFile;
 	BCheckBox*	fDoAll;
 	bool		fReplace;
 
@@ -26,10 +27,11 @@ class ConflictWindow : public BWindow
 
 	void			MessageReceived(BMessage* msg);
 	BStringView*	_CreateLabelView(const char* label);
-	BStringView*	_CreateAttrView(const char* file, const char* folder);
+	BStringView*	_CreateAttrView(const char* folder);
 
 public:
-			ConflictWindow(const char* file, const char* src, const char* dest,
+			ConflictWindow(const char* srcFolder, const entry_ref& srcFile,
+				const char* destFolder, const entry_ref& destFile,
 				const char* desc);
 	bool	Go(bool& doAll);
 };

--- a/sources/FolderPathView.cpp
+++ b/sources/FolderPathView.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Haiku, Inc.
+ * Distributed under the terms of the MIT License.
+ *
+ * Author:
+ *			Owen Pan <owen.pan@yahoo.com>
+ */
+
+
+#include "FolderPathView.h"
+
+#include <Catalog.h>
+#include <MenuItem.h>
+#include <Roster.h>
+#include <Window.h>
+
+#include <private/shared/LongAndDragTrackingFilter.h>
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "FolderPathView"
+
+static const uint32 kMouseLongDown = 'Mold';
+static const uint32 kOpenFolder = 'Opfd';
+static const uint32 kOpenFile = 'Opfl';
+
+
+FolderPathView::FolderPathView(const BString& path, const entry_ref& ref)
+	:
+	BStringView("", path),
+	fFileRef(ref)
+{
+	SetHighUIColor(B_LINK_TEXT_COLOR);
+	get_ref_for_path(path, &fFolderRef);
+
+	fPopupMenu = new BPopUpMenu("", false, false);
+	fPopupMenu->AddItem(new BMenuItem(B_TRANSLATE("Open folder"),
+		new BMessage(kOpenFolder)));
+	fPopupMenu->AddItem(new BMenuItem(B_TRANSLATE("Open file"),
+		new BMessage(kOpenFile)));
+}
+
+
+void
+FolderPathView::AttachedToWindow()
+{
+	AddFilter(new LongAndDragTrackingFilter(kMouseLongDown, 0));
+	fPopupMenu->SetTargetForItems(this);
+}
+
+
+void
+FolderPathView::MessageReceived(BMessage* msg)
+{
+	switch (msg->what) {
+		case kMouseLongDown:
+		{
+			BPoint where;
+			if (msg->FindPoint("where", &where) == B_OK)
+				fPopupMenu->Go(ConvertToScreen(where), true);
+
+			break;
+		}
+		case kOpenFolder:
+			_OpenFolder();
+			break;
+		case kOpenFile:
+			be_roster->Launch(&fFileRef);
+			break;
+		default:
+			BStringView::MessageReceived(msg);
+	}
+}
+
+
+void
+FolderPathView::MouseMoved(BPoint where, uint32 transit, const BMessage* msg)
+{
+	switch (transit) {
+		case B_ENTERED_VIEW:
+			SetHighUIColor(B_LINK_HOVER_COLOR);
+			Invalidate();
+			break;
+		case B_EXITED_VIEW:
+			SetHighUIColor(B_LINK_TEXT_COLOR);
+			Invalidate();
+	}
+}
+
+
+void
+FolderPathView::MouseUp(BPoint where)
+{
+	if (Bounds().Contains(where))
+		_OpenFolder();
+}
+
+
+void
+FolderPathView::_OpenFolder()
+{
+	BMessage msgRef(B_REFS_RECEIVED);
+	msgRef.AddRef("refs", &fFolderRef);
+
+	BMessage msgSel('Tsel');
+	msgSel.AddRef("refs", &fFileRef);
+
+	BList msgList(2);
+	msgList.AddItem(&msgRef);
+	msgList.AddItem(&msgSel);
+
+	be_roster->Launch("application/x-vnd.Be-TRAK", &msgList);
+}

--- a/sources/FolderPathView.h
+++ b/sources/FolderPathView.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Haiku, Inc.
+ * Distributed under the terms of the MIT License.
+ *
+ * Author:
+ *			Owen Pan <owen.pan@yahoo.com>
+ */
+
+#ifndef FOLDER_PATH_VIEW_H
+#define FOLDER_PATH_VIEW_H
+
+#include <Entry.h>
+#include <PopUpMenu.h>
+#include <StringView.h>
+
+class FolderPathView : public BStringView
+{
+	void	AttachedToWindow();
+	void	MessageReceived(BMessage* msg);
+	void	MouseMoved(BPoint where, uint32 transit, const BMessage* dragMsg);
+	void	MouseUp(BPoint where);
+
+	void	_OpenFolder();
+
+	entry_ref	fFolderRef;
+	entry_ref	fFileRef;
+	BPopUpMenu*	fPopupMenu;
+
+public:
+			FolderPathView(const BString& path, const entry_ref& ref);
+			~FolderPathView() { delete fPopupMenu; }
+};
+
+#endif	// FOLDER_PATH_VIEW_H

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -33,7 +33,7 @@ SRCS = AutoFilerTab.cpp FilerRule.cpp FSUtils.cpp main.cpp PatternProcessor.cpp 
 	DropZoneTab.cpp HelpTab.cpp MainWindow.cpp RefStorage.cpp ReplicantWindow.cpp \
 	RuleEditWindow.cpp RuleItem.cpp RuleTab.cpp TypedRefFilter.cpp TestView.cpp \
 	ConflictWindow.cpp ModeMenu.cpp AddRemoveButtons.cpp PanelButton.cpp \
-	RuleItemList.cpp ContextPopUp.cpp AutoFilerList.cpp
+	RuleItemList.cpp ContextPopUp.cpp AutoFilerList.cpp FolderPathView.cpp
 
 #	Specify the resource definition files to use. Full or relative paths can be
 #	used.

--- a/sources/RuleRunner.cpp
+++ b/sources/RuleRunner.cpp
@@ -770,6 +770,7 @@ MoveOrCopy(const BMessage& action, const entry_ref& ref, const char* desc,
 	bool doAll = app->DoAll();
 	bool replace = app->Replace();
 
+	entry_ref destRef;
 	const char* name = ref.name;
 	bool conflict = false;
 
@@ -786,6 +787,8 @@ MoveOrCopy(const BMessage& action, const entry_ref& ref, const char* desc,
 			return B_ERROR;
 
 		conflict = dest.Exists();
+		if (conflict)
+			dest.GetRef(&destRef);
 	}
 
 	if (conflict && !doAll) {
@@ -799,8 +802,8 @@ MoveOrCopy(const BMessage& action, const entry_ref& ref, const char* desc,
 		if (path.InitCheck() != B_OK)
 			return B_ERROR;
 
-		ConflictWindow* window = new ConflictWindow(name, path.Path(), destDir,
-			desc);
+		ConflictWindow* window = new ConflictWindow(path.Path(), ref, destDir,
+			destRef, desc);
 		replace = window->Go(doAll);
 		delete window;
 

--- a/sources/TestView.cpp
+++ b/sources/TestView.cpp
@@ -277,7 +277,7 @@ TestView::TestMenu() const
 	// These ones will always exist. Type is the default because it's probably
 	// going to be the one most used
 	BMessage* msg;
-	BPopUpMenu* menu = new BPopUpMenu("", true, false);
+	BPopUpMenu* menu = new BPopUpMenu("", false, false);
 
 	// Read in the types in the MIME database which have extra attributes
 	// associated with them


### PR DESCRIPTION
Add vertical padding within the grid layout in `ConflictWindow`
(thanks to @humdingerb's code).

Also, add long-click popup menus for opening source/target folder/file.

Finally, make `ConflictWindow` resemble the "Get info" window of Tracker:

* Change the format of date/time.

* Change the color of source/target folder path.

* Right-align labels.

* Make the text color of the 2nd column lighter.

* Remove the italic face for date/time and size.

* Change the visual cue for mouse over the source/target folder path.