### PR TITLE
Don't show generic files including symlinks to them in Archive and

### DIFF
--- a/sources/TypedRefFilter.cpp
+++ b/sources/TypedRefFilter.cpp
@@ -87,6 +87,6 @@ TypedRefFilter::Filter(const entry_ref* ref, BNode* node, struct stat_beos* st,
 	if (fFileType.IsEmpty())
 		return true;
 
-	return isDir || fFileType == filetype
+	return isDir || fFileType == filetype || *filetype == '\0'
 			|| strcmp(filetype, "application/octet-stream") == 0;
 }


### PR DESCRIPTION
Command file panels.

Don't accept drag&drop'ed generic files (inlcuding symlinks to them) in
Archive and Command text entries.