### PR TITLE
Store rules in flattened message instead of SQLite

### DIFF
--- a/sources/FSUtils.cpp
+++ b/sources/FSUtils.cpp
@@ -35,7 +35,7 @@ status_t CheckCopiable(BEntry* src, BEntry* dest)
 		return B_ERROR;
 
 	if (!src->Exists())
-		return B_FILE_NOT_FOUND;
+		return B_ENTRY_NOT_FOUND;
 
 	// Ensure that when we want the destination directory, that is exactly
 	// what we're working with. If we've been given an entry which is a file,

--- a/sources/FilerRule.h
+++ b/sources/FilerRule.h
@@ -29,24 +29,28 @@ class FilerRule : public BArchivable
 public:
 								FilerRule();
 								FilerRule(FilerRule& rule);
+								FilerRule(BMessage* data);
 								~FilerRule();
-			
+
+	virtual status_t			Archive(BMessage* into, bool deep = true);
+	static FilerRule*	Instantiate(BMessage* archive);
+
 			void				SetRuleMode(const filer_rule_mode& mode);
 			filer_rule_mode		GetRuleMode() const { return fMode; }
-			
+
 			const char*			GetDescription() const;
 			void				SetDescription(const char* desc);
-			
+
 			void				AddTest(BMessage* item, const int32& index = -1);
 			BMessage*			RemoveTest(const int32& index);
 			BMessage*			TestAt(const int32& index);
 			int32				CountTests() const;
-			
+
 			void				AddAction(BMessage* action, const int32& index = -1);
 			BMessage*			RemoveAction(const int32& index);
 			BMessage*			ActionAt(const int32& index);
 			int32				CountActions() const;
-			
+
 			void				MakeEmpty();
 	virtual	void				PrintToStream();
 			FilerRule&			operator=(FilerRule& from);
@@ -55,7 +59,7 @@ public:
 			bool				Disabled() const { return fDisabled; }
 			void				Disabled(bool disabled) { fDisabled = disabled; }
 			void				Toggle() { fDisabled = !fDisabled; }
-			
+
 private:
 	BObjectList<BMessage>*		fTestList;
 	BObjectList<BMessage>*		fActionList;

--- a/sources/RuleRunner.h
+++ b/sources/RuleRunner.h
@@ -84,8 +84,12 @@ public:
 
 int32		GetDataTypeForTest(int8 testtype);
 int32		GetDataTypeForMode(int8 modetype);
+
 status_t	LoadRules(BObjectList<FilerRule>* ruleList);
 status_t	SaveRules(const BObjectList<FilerRule>* ruleList);
+
+status_t	LoadSQLRules(BObjectList<FilerRule>* ruleList);
+
 int8		AttributeTestType();
 bool		ActionHasTarget(int8 type);
 bool		SetTextForType(BString& text, int8 type, const entry_ref& ref,
@@ -93,5 +97,6 @@ bool		SetTextForType(BString& text, int8 type, const entry_ref& ref,
 bool		SetTextForMime(BString& text, const entry_ref& ref);
 bool		SetTextForSize(BString& text, const entry_ref& ref);
 void		AddDefaultRules(BObjectList<FilerRule>* ruleList);
+
 
 #endif	// RULERUNNER_H


### PR DESCRIPTION
Swaps over from using SQLite for rule storage to a flattened message, migrating over old SQL rules and backing up the old DB.