### PR TITLE
Tweak escaping of single-quotes in file copying

### DIFF
--- a/sources/FSUtils.h
+++ b/sources/FSUtils.h
@@ -1,12 +1,12 @@
 /*
-	FSUtils.h: Utility classes for basic filesystem operations
-	Written by DarkWyrm <darkwyrm@gmail.com>, Copyright 2008
-	Released under the MIT license.
-*/
+ * Copyright 2008, DarkWyrm <darkwyrm@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
 
 #ifndef FSUTILS_H_
 #define FSUTILS_H_
 
+#include <Entry.h>
 #include <Errors.h>
 
 #define FS_CLOBBER 'fscl'
@@ -17,8 +17,5 @@ status_t	CopyFile(BEntry* src, BEntry* dest, bool clobber);
 status_t	MoveFile(BEntry* src, BEntry* dest, bool clobber);
 
 const char*	GetValidName(BEntry* entry);
-bool 		IsFilenameChar(char c);
-int 		charcmp(char c1, char c2);
-int 		charncmp(char c1, char c2);
 
 #endif	// FSUTILS_H_


### PR DESCRIPTION
And remove unused functions in FSUtils.

Apparently in bash, within a single-quoted string you can escape single-quotes, but it's a little weird: Instead of ' → \', it's ' → '\'' which breaks the string to add the single-quote. TIL!